### PR TITLE
Gnuplot: optional graph generation

### DIFF
--- a/src/unix/metrics_gnuplot.ml
+++ b/src/unix/metrics_gnuplot.ml
@@ -286,7 +286,8 @@ let set_reporter ?dir ?(output=`Image) () =
     (* Close all the raw data files *)
     Raw.Tbl.iter (fun _ f -> f.close ()) t.raw;
     match output with
-    | `Datafile -> ()
+    | `Datafile ->
+      Raw.Tbl.iter (fun _ f -> Fmt.pr "%s has been created.\n%!" f.name) t.raw
     | `Script ->
       List.iter (plot_graph t ~output_format:`Script ~xlabel:`Timestamp) graphs;
       List.iter (plot_graph t ~output_format:`Script ~xlabel:`Duration) graphs

--- a/src/unix/metrics_gnuplot.mli
+++ b/src/unix/metrics_gnuplot.mli
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val set_reporter : ?dir:string -> ?render:bool -> unit -> unit
+val set_reporter : ?dir:string -> ?output:[ `Image | `Script | `Datafile ] -> unit -> unit

--- a/src/unix/metrics_gnuplot.mli
+++ b/src/unix/metrics_gnuplot.mli
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val set_reporter : ?dir:string -> unit -> unit
+val set_reporter : ?dir:string -> ?render:bool -> unit -> unit


### PR DESCRIPTION
This makes the graph generation for the Gnuplot backend optional, leading to three tiers of operation:
 1. `` `Datafile``: output datafile only
 2. `` `Script``: output Gnuplot script + datafile only
 3. `` `Image``: output PNG image + script + datafile

This is useful when the data from the reporter is to be processed by a separate tool, e.g. a tool that diffs the results from multiple runs.