### PR TITLE
Add modern Travis runners

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,9 @@ env:
   - DISTRO="debian-stable"
   matrix:
   - PACKAGE="metrics" OCAML_VERSION="4.04"
+  - PACKAGE="metrics" OCAML_VERSION="4.05"
+  - PACKAGE="metrics" OCAML_VERSION="4.06"
+  - PACKAGE="metrics" OCAML_VERSION="4.07"
+  - PACKAGE="metrics" OCAML_VERSION="4.08"
   - PACKAGE="metrics-lwt" OCAML_VERSION="4.05"
   - PACKAGE="metrics-unix" OCAML_VERSION="4.06"


### PR DESCRIPTION
This adds Travis CI runners for OCaml versions 4.05 -- 4.08 on the core `metrics` package. Currently the only version being tested is 4.04.