### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/metrics-influx.opam
+++ b/metrics-influx.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune" {build}
+  "dune"
   "metrics"
   "astring"
   "fmt"

--- a/metrics-lwt.opam
+++ b/metrics-lwt.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune" {build}
+  "dune"
   "metrics"
   "lwt"
 ]

--- a/metrics-mirage.opam
+++ b/metrics-mirage.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune" {build}
+  "dune"
   "metrics"
   "lwt"
   "metrics-influx"

--- a/metrics-unix.opam
+++ b/metrics-unix.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune" {build}
+  "dune"
   "uuidm"
   "metrics"
   "mtime"

--- a/metrics.opam
+++ b/metrics.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build}
+  "dune"
   "fmt"
   "alcotest" {with-test}
 ]


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.