### PR TITLE
metrics enhancements

### DIFF
--- a/metrics-influx.opam
+++ b/metrics-influx.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "dune"
-  "metrics"
+  "metrics" {= version}
   "astring"
   "fmt"
   "duration"

--- a/metrics-lwt.opam
+++ b/metrics-lwt.opam
@@ -17,5 +17,6 @@ depends: [
   "dune"
   "metrics"
   "lwt"
+  "logs"
 ]
 synopsis: "Lwt backend for the Metrics library"

--- a/metrics-lwt.opam
+++ b/metrics-lwt.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "dune"
-  "metrics"
+  "metrics" {= version}
   "lwt"
   "logs"
 ]

--- a/metrics-mirage.opam
+++ b/metrics-mirage.opam
@@ -20,8 +20,8 @@ depends: [
   "metrics-influx"
   "ipaddr"
   "lwt"
-  "mirage-clock"
-  "mirage-stack-lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.0.0"}
   "cstruct"
   "logs"
 ]

--- a/src/core/metrics.ml
+++ b/src/core/metrics.ml
@@ -430,6 +430,16 @@ let () = at_exit (fun () -> !_reporter.at_exit ())
 
 let now () = !_reporter.now ()
 
+module SM = Map.Make(Src)
+
+let cache_reporter () =
+  let m = ref SM.empty in
+  let report ~tags ~data ~over src k =
+    m := SM.add src (tags, data) !m;
+    over (); k ()
+  in
+  (fun () -> !m), { report ; now ; at_exit = (fun () -> ()) }
+
 let report src ~over ~k tags f =
   let tags = tags (tag src) in
   f src.Src.data (fun data -> !_reporter.report ~tags ~data ~over (Src src) k)

--- a/src/core/metrics.mli
+++ b/src/core/metrics.mli
@@ -480,6 +480,22 @@ val reporter : unit -> reporter
 val set_reporter : reporter -> unit
 (** [set_reporter r] sets the current reporter to [r]. *)
 
+module SM : Map.S with type key = Src.t
+
+val cache_reporter : unit ->
+  (unit -> (tags * data) SM.t) * reporter
+(** [cache_reporter now ()] is a reporter that stores the last measurement from
+    each source in a map (which can be retrieved by the returned function).
+    This is an initial attempt to overcome the push vs pull interface. Each
+    measurement _event_ is sent at an arbitrary point in time, while reporting
+    over a communication channel may be rate-limited (i.e. report every 10
+    seconds statistics, rather than whenever they appear).
+
+    This is only a good idea for counters, histograms etc. may be useful for
+    other numbers (such as time consumed between receive and send - the
+    measurement should provide the information whether it's a counter or sth
+    else). *)
+
 (** {2:runtime OCaml Gc sources}
 
     The {{:http://caml.inria.fr/pub/docs/manual-ocaml/libref/Gc.html}Gc} module

--- a/src/influx/metrics_influx.ml
+++ b/src/influx/metrics_influx.ml
@@ -157,7 +157,6 @@ let lwt_reporter ?tags:(more_tags = []) ?interval send now =
   let report ~tags ~data ~over src k =
     let send () =
       m := SM.add src (now ()) !m;
-      Printf.printf "sending\n";
       let str =
         encode_line_protocol (more_tags @ tags) data (Metrics.Src.name src)
       in
@@ -168,14 +167,10 @@ let lwt_reporter ?tags:(more_tags = []) ?interval send now =
       Lwt.finalize (fun () -> send str) unblock |> Lwt.ignore_result;
       k ()
     in
-    Printf.printf "%s reporting at %Lu ns\n" (Metrics.Src.name src)
-      (Int64.sub (now ()) start);
     match SM.find_opt src !m with
     | None -> send ()
     | Some last ->
       if now () > Int64.add last i then send ()
-      else (
-        over ();
-        k () )
+      else ( over (); k () )
   in
   { Metrics.report; now; at_exit = (fun () -> ()) }

--- a/src/influx/metrics_influx.ml
+++ b/src/influx/metrics_influx.ml
@@ -153,7 +153,6 @@ module SM = Map.Make (Metrics.Src)
 let lwt_reporter ?tags:(more_tags = []) ?interval send now =
   let m = ref SM.empty in
   let i = match interval with None -> 0L | Some s -> Duration.of_ms s in
-  let start = now () in
   let report ~tags ~data ~over src k =
     let send () =
       m := SM.add src (now ()) !m;

--- a/src/influx/metrics_influx.mli
+++ b/src/influx/metrics_influx.mli
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+val encode_line_protocol : Metrics.tags -> Metrics.data -> string -> string
+
 val lwt_reporter :
   ?tags:Metrics.tags ->
   ?interval:int ->

--- a/src/lwt/dune
+++ b/src/lwt/dune
@@ -1,4 +1,4 @@
 (library
   (name        metrics_lwt)
   (public_name metrics-lwt)
-  (libraries   lwt metrics))
+  (libraries   lwt metrics logs))

--- a/src/lwt/metrics_lwt.ml
+++ b/src/lwt/metrics_lwt.ml
@@ -89,3 +89,32 @@ let rrun src tags g =
         ?status:(status `Error)
         (fun f -> Lwt.return (f (Error x)))
       >|= fun () -> raise e
+
+let periodic = ref []
+
+let periodically src = periodic := src :: !periodic
+
+let log_stats ~tags =
+  let doc = "Statistics of the Logs library" in
+  let data () =
+    let warnings, errors = Logs.warn_count (), Logs.err_count () in
+    Data.v
+      [ int "warnings" warnings ; int "errors" errors ]
+  in
+  Src.v ~doc ~tags ~data "logs"
+
+let init_periodic ?(gc = `Full) ?(logs = true) sleeper =
+  (match gc with
+   | `None -> ()
+   | `Quick -> periodically (gc_quick_stat ~tags:Tags.[])
+   | `Full -> periodically (gc_stat ~tags:Tags.[]));
+  (if logs then periodically (log_stats ~tags:Tags.[]));
+  let collect () =
+    List.iter (fun src -> Metrics.add src (fun x -> x) (fun d -> d ()))
+      !periodic;
+    Lwt.return_unit
+  in
+  let rec loop () =
+    Lwt.join [ sleeper () ; collect () ] >>= loop
+  in
+  Lwt.async loop

--- a/src/lwt/metrics_lwt.mli
+++ b/src/lwt/metrics_lwt.mli
@@ -44,3 +44,14 @@ val rrun :
   (unit -> ('b, 'c) result Lwt.t) ->
   ('b, 'c) result Lwt.t
 (** Same as {!run} but also record if the result is [Ok] or [Error]. *)
+
+val periodically : (field list, unit -> data) src -> unit
+(** [periodically src] registers [src] for periodic collection. *)
+
+val init_periodic : ?gc:[ `None | `Quick | `Full ] -> ?logs:bool ->
+  (unit -> unit Lwt.t) -> unit
+(** [init_periodic ~gc ~logs sleeper] starts a task which {!Lwt.join} [sleeper]
+    and all registered {!periodically} sources. [gc] is by default [`Full],
+    collecting full GC stats - other options are [`None] and [`Quick]. If [logs]
+    is provided and [true] (the default), the error and warning count from the
+    Logs library are registered to be periodically reported. *)

--- a/src/mirage/dune
+++ b/src/mirage/dune
@@ -2,4 +2,4 @@
   (name        metrics_mirage)
   (public_name metrics-mirage)
   (synopsis    "Mirage metrics reporter")
-  (libraries   metrics metrics-influx ipaddr lwt mirage-clock mirage-stack-lwt cstruct logs))
+  (libraries   metrics metrics-influx ipaddr lwt mirage-clock mirage-stack cstruct logs))

--- a/src/mirage/metrics_mirage.ml
+++ b/src/mirage/metrics_mirage.ml
@@ -20,14 +20,14 @@ let src = Logs.Src.create "influx" ~doc:"influx metrics reporter"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Influx (CLOCK : Mirage_clock.MCLOCK) (STACK : Mirage_stack_lwt.V4) =
+module Influx (CLOCK : Mirage_clock.MCLOCK) (STACK : Mirage_stack.V4) =
 struct
   module TCP = STACK.TCPV4
 
   let vmname =
     Metrics.field ~doc:"name of the virtual machine" "vm" Metrics.String
 
-  let create clock stack ?interval ?hostname dst ?(port = 8094) () =
+  let create stack ?interval ?hostname dst ?(port = 8094) () =
     let tcp = STACK.tcpv4 stack in
     let f = ref None in
     let m = Lwt_mutex.create () in
@@ -67,7 +67,7 @@ struct
     in
     connect () >|= function
     | Ok () ->
-      let now () = CLOCK.elapsed_ns clock
+      let now () = CLOCK.elapsed_ns ()
       and tags =
         match hostname with None -> [] | Some host -> [ vmname host ]
       in

--- a/src/mirage/metrics_mirage.mli
+++ b/src/mirage/metrics_mirage.mli
@@ -16,19 +16,18 @@
 (** Metrics reporters using MirageOS *)
 
 (** Influx reporter *)
-module Influx (CLOCK : Mirage_clock.MCLOCK) (STACK : Mirage_stack_lwt.V4) : sig
+module Influx (CLOCK : Mirage_clock.MCLOCK) (STACK : Mirage_stack.V4) : sig
   val vmname : string -> Metrics.field
   (** [vmname name] creates a [tag] with the virtual machine name. *)
 
   val create :
-    CLOCK.t ->
     STACK.t ->
     ?interval:int ->
     ?hostname:string ->
-    STACK.ipv4addr ->
+    STACK.TCPV4.ipaddr ->
     ?port:int ->
     unit ->
-    (Metrics.reporter, unit) result STACK.io
+    (Metrics.reporter, unit) result Lwt.t
   (** [create mclock stack ~interval ~hostname ip ~port ()] is [reporter], which
      sends measurements (prefixed by [vmname hosttname] if provided), to
      [ip:port] (defaults to 8094).  If [interval] is provided, measurements from


### PR DESCRIPTION
see individual commits for details, briefly:
- includes #42 (a caching reporter)
- expose the "encode_line_protocol" function
- Metrics_lwt: provide a source based on Logs.warn_count and Logs.error_count
- Metrics_lwt: provide a function to periodically poll a source (used e.g. for GC stats etc.)
- fix the mirage subpackage for newer mirage APIs

This code has been used for several months in various unikernels and other applications, I'm happy for any feedback.