### PR TITLE
metrix-unix: Only use mtime.clock.os

### DIFF
--- a/src/unix/dune
+++ b/src/unix/dune
@@ -2,5 +2,4 @@
   (name        metrics_gnuplot)
   (public_name metrics-unix)
   (wrapped     false)
-  (libraries   lwt.unix metrics fmt uuidm unix mtime mtime.clock
-               mtime.clock.os))
+  (libraries   lwt.unix metrics fmt uuidm unix mtime mtime.clock.os))


### PR DESCRIPTION
This should fix #57.