### PR TITLE
Metrics: add a get_cache function to allow multiple consumers of the cache reporter

### DIFF
--- a/src/core/metrics.ml
+++ b/src/core/metrics.ml
@@ -358,14 +358,17 @@ let now () = !_reporter.now ()
 
 module SM = Map.Make (Src)
 
+let _cache = ref SM.empty
+
+let get_cache () = !_cache
+
 let cache_reporter () =
-  let m = ref SM.empty in
   let report ~tags ~data ~over src k =
-    m := SM.add src (tags, data) !m;
+    _cache := SM.add src (tags, data) !_cache;
     over ();
     k ()
   in
-  ((fun () -> !m), { report; now; at_exit = (fun () -> ()) })
+  (get_cache, { report; now; at_exit = (fun () -> ()) })
 
 let report src ~over ~k tags f =
   let tags = tags (tag src) in

--- a/src/core/metrics.ml
+++ b/src/core/metrics.ml
@@ -362,10 +362,12 @@ let _cache = ref SM.empty
 
 let get_cache () = !_cache
 
-let cache_reporter () =
+let cache_reporter ?cb () =
+  let call = match cb with Some f -> f | None -> Fun.id in
   let report ~tags ~data ~over src k =
     _cache := SM.add src (tags, data) !_cache;
     over ();
+    call ();
     k ()
   in
   (get_cache, { report; now; at_exit = (fun () -> ()) })

--- a/src/core/metrics.ml
+++ b/src/core/metrics.ml
@@ -359,7 +359,6 @@ let now () = !_reporter.now ()
 module SM = Map.Make (Src)
 
 let _cache = ref SM.empty
-
 let get_cache () = !_cache
 
 let cache_reporter ?cb () =

--- a/src/core/metrics.ml
+++ b/src/core/metrics.ml
@@ -370,7 +370,7 @@ let cache_reporter ?cb () =
     call src tags data;
     k ()
   in
-  (get_cache, { report; now; at_exit = (fun () -> ()) })
+  { report; now; at_exit = (fun () -> ()) }
 
 let report src ~over ~k tags f =
   let tags = tags (tag src) in

--- a/src/core/metrics.ml
+++ b/src/core/metrics.ml
@@ -363,11 +363,11 @@ let _cache = ref SM.empty
 let get_cache () = !_cache
 
 let cache_reporter ?cb () =
-  let call = match cb with Some f -> f | None -> Fun.id in
+  let call = match cb with Some f -> f | None -> fun _ _ _ -> () in
   let report ~tags ~data ~over src k =
     _cache := SM.add src (tags, data) !_cache;
     over ();
-    call ();
+    call src tags data;
     k ()
   in
   (get_cache, { report; now; at_exit = (fun () -> ()) })

--- a/src/core/metrics.mli
+++ b/src/core/metrics.mli
@@ -464,7 +464,8 @@ val set_reporter : reporter -> unit
 
 module SM : Map.S with type key = Src.t
 
-val cache_reporter : ?cb:(unit -> unit) -> unit -> (unit -> (tags * data) SM.t) * reporter
+val cache_reporter : ?cb:(Src.t -> tags -> data -> unit) -> unit ->
+  (unit -> (tags * data) SM.t) * reporter
 (** [cache_reporter ?cb ()] is a reporter that stores the last measurement from
     each source in a map (which can be retrieved by the returned function). This
     overcomes the push vs pull interface. Each measurement _event_ is sent at an

--- a/src/core/metrics.mli
+++ b/src/core/metrics.mli
@@ -464,8 +464,7 @@ val set_reporter : reporter -> unit
 
 module SM : Map.S with type key = Src.t
 
-val cache_reporter : ?cb:(Src.t -> tags -> data -> unit) -> unit ->
-  reporter
+val cache_reporter : ?cb:(Src.t -> tags -> data -> unit) -> unit -> reporter
 (** [cache_reporter ?cb ()] is a reporter that stores the last measurement from
     each source in a map (which can be retrieved by {!get_cache} below). This
     overcomes the push vs pull interface. Each measurement _event_ is sent at an

--- a/src/core/metrics.mli
+++ b/src/core/metrics.mli
@@ -465,9 +465,9 @@ val set_reporter : reporter -> unit
 module SM : Map.S with type key = Src.t
 
 val cache_reporter : ?cb:(Src.t -> tags -> data -> unit) -> unit ->
-  (unit -> (tags * data) SM.t) * reporter
+  reporter
 (** [cache_reporter ?cb ()] is a reporter that stores the last measurement from
-    each source in a map (which can be retrieved by the returned function). This
+    each source in a map (which can be retrieved by {!get_cache} below). This
     overcomes the push vs pull interface. Each measurement _event_ is sent at an
     arbitrary point in time, while reporting over a communication channel may be
     rate-limited (i.e. report every 10 seconds statistics, rather than whenever

--- a/src/core/metrics.mli
+++ b/src/core/metrics.mli
@@ -464,13 +464,14 @@ val set_reporter : reporter -> unit
 
 module SM : Map.S with type key = Src.t
 
-val cache_reporter : unit -> (unit -> (tags * data) SM.t) * reporter
-(** [cache_reporter now ()] is a reporter that stores the last measurement from
+val cache_reporter : ?cb:(unit -> unit) -> unit -> (unit -> (tags * data) SM.t) * reporter
+(** [cache_reporter ?cb ()] is a reporter that stores the last measurement from
     each source in a map (which can be retrieved by the returned function). This
-    is an initial attempt to overcome the push vs pull interface. Each
-    measurement _event_ is sent at an arbitrary point in time, while reporting
-    over a communication channel may be rate-limited (i.e. report every 10
-    seconds statistics, rather than whenever they appear).
+    overcomes the push vs pull interface. Each measurement _event_ is sent at an
+    arbitrary point in time, while reporting over a communication channel may be
+    rate-limited (i.e. report every 10 seconds statistics, rather than whenever
+    they appear). The optional [cb] function is called for each measurement that
+    gets reported.
 
     This is only a good idea for counters, histograms etc. may be useful for
     other numbers (such as time consumed between receive and send - the

--- a/src/core/metrics.mli
+++ b/src/core/metrics.mli
@@ -480,7 +480,8 @@ val cache_reporter : ?cb:(Src.t -> tags -> data -> unit) -> unit ->
     else). *)
 
 val get_cache : unit -> (tags * data) SM.t
-(** [get_cache ()] is the current data of the cache reporter. *)
+(** [get_cache ()] is the current data of the cache reporter. The cache is only
+    filled if [cache_reporter ?cb ()] is set as a reporter. *)
 
 (** {2:runtime OCaml Gc sources}
 

--- a/src/core/metrics.mli
+++ b/src/core/metrics.mli
@@ -477,6 +477,9 @@ val cache_reporter : unit -> (unit -> (tags * data) SM.t) * reporter
     measurement should provide the information whether it's a counter or sth
     else). *)
 
+val get_cache : unit -> (tags * data) SM.t
+(** [get_cache ()] is the current data of the cache reporter. *)
+
 (** {2:runtime OCaml Gc sources}
 
     The {{:http://caml.inria.fr/pub/docs/manual-ocaml/libref/Gc.html} Gc} module


### PR DESCRIPTION
i.e. some time series database and as well a web interface.