### PR TITLE
Allow only a single metrics source for each name

### DIFF
--- a/src/core/metrics.ml
+++ b/src/core/metrics.ml
@@ -123,7 +123,8 @@ module Src = struct
     let dom = Tags.domain tags in
     let active = active dom in
     if List.exists (fun (Src src) -> String.equal src.name name) !list then
-      invalid_arg ("a metrics source with the same name (" ^ name ^ ") already exists");
+      invalid_arg
+        ("a metrics source with the same name (" ^ name ^ ") already exists");
     let src =
       {
         duration;
@@ -159,8 +160,8 @@ module Src = struct
     let tags = Keys.elements (Tags.domain src.tags) in
     let data = match src.data_fields with None -> [] | Some l -> l in
     Format.fprintf ppf
-      "@[<1>(src@   @[<1>(name %S)@]@   @[<1>(doc %S)@])   \
-       @[<1>(tags (%a))@]   @[<1>(data (%a))@] @]"
+      "@[<1>(src@   @[<1>(name %S)@]@   @[<1>(doc %S)@])   @[<1>(tags \
+       (%a))@]   @[<1>(data (%a))@] @]"
       src.name src.doc pp_strings tags pp_strings data
 
   let list () = !list

--- a/src/core/metrics.mli
+++ b/src/core/metrics.mli
@@ -293,6 +293,9 @@ module Src : sig
       the various metrics. The source will be enabled on creation iff one of tag
       in [tags] has been enabled with {!enable_tag}.
 
+      If there's already a source with the name, an Invalid_argument exception
+      is raised.
+
       For instance, to create a metric to collect CPU and memory usage on
       various machines, indexed by [PID], [host] name and [IP] address:
 

--- a/test/unix/test.ml
+++ b/test/unix/test.ml
@@ -44,7 +44,7 @@ let src =
   let data i =
     Data.v [ float "CPU" ~graph (float_of_int i ** 2.); int "MEM" ~graph i ]
   in
-  Src.v "test" ~tags ~data
+  Src.v "test2" ~tags ~data
 
 let i0 t = t "foo"
 let i1 t = t "bar"


### PR DESCRIPTION
This avoids the issue of having multiple sources with the same name, which in some scenarios leads to an excessive use of memory. Also, this allows us to remove the 'uid' field of the Src.t.